### PR TITLE
[SpringBoot Example] use customized metrics to scale Provisioned Concurrency

### DIFF
--- a/examples/springboot/template.yaml
+++ b/examples/springboot/template.yaml
@@ -60,8 +60,16 @@ Resources:
       ScalingTargetId: !Ref MyScalableTarget
       TargetTrackingScalingPolicyConfiguration:
         TargetValue: 0.70 # Any value between 0 and 1 can be used here
-        PredefinedMetricSpecification:
-          PredefinedMetricType: LambdaProvisionedConcurrencyUtilization
+        CustomizedMetricSpecification:
+          Dimensions:
+            - Name: FunctionName
+              Value: !Ref PetstoreFunction
+            - Name: Resource
+              Value: !Sub "${PetstoreFunction}:live"
+          MetricName: ProvisionedConcurrencyUtilization
+          Namespace: AWS/Lambda
+          Statistic: Maximum
+          Unit: Count
 
 Outputs:
   PetstoreApi:


### PR DESCRIPTION

*Description of changes:*

Use maximum value for ProvisionedConcurrencyUtilization to scale PC faster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
